### PR TITLE
Making ProjCL build/run on Linux, use GPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,18 +168,28 @@ if (PROJ4_FOUND)
 	add_definitions(-DHAVE_PROJ4)
 endif (PROJ4_FOUND)	
 
-include_directories(${PROJ_INCLUDE_DIR})
-
 find_package(OpenCL)
-find_package(Blas)
+
+if (APPLE)
+   find_package(BLAS)
+elseif(WIN32)
+else()
+    # Regrettably necessary
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .so.3 ${CMAKE_FIND_LIBRARY_SUFFIXES})
+
+    find_package(CBLAS REQUIRED)
+
+    # This also finds BLAS REQUIRED; both are needed on Linux
+    find_package(LAPACK REQUIRED)
+
+    set(RANDOM_LINUX_LIBRARIES m)
+endif()
 
 
-set(PROJCL_DEPENDENT_LIBRARIES ${OPENCL_LIBRARIES} ${PROJ4_LIBRARIES} ${BLAS_LIBRARIES})
+include_directories(${PROJ_INCLUDE_DIR} ${OPENCL_INCLUDE_DIRS} ${CBLAS_INCLUDE_DIR})
+
+set(PROJCL_DEPENDENT_LIBRARIES ${OPENCL_LIBRARIES} ${PROJ4_LIBRARIES} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${CBLAS_LIBRARIES} ${RANDOM_LINUX_LIBRARIES}
+)
 add_subdirectory(src)
 
 add_subdirectory(test)
-
-
-
-
-

--- a/cmake/modules/FindCBLAS.cmake
+++ b/cmake/modules/FindCBLAS.cmake
@@ -1,0 +1,21 @@
+# include(FindLibraryWithDebug)
+
+if (CBLAS_INCLUDE_DIR AND CBLAS_LIBRARIES)
+  set(CBLAS_FIND_QUIETLY TRUE)
+endif (CBLAS_INCLUDE_DIR AND CBLAS_LIBRARIES)
+
+find_path(CBLAS_INCLUDE_DIR
+  NAMES cblas.h
+  PATHS $ENV{CBLASDIR}/include ${INCLUDE_INSTALL_DIR}
+)
+
+find_library(CBLAS_LIBRARIES
+  FILES cblas
+  PATHS $ENV{CBLASDIR}/src ${LIB_INSTALL_DIR}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CBLAS DEFAULT_MSG
+                                  CBLAS_INCLUDE_DIR CBLAS_LIBRARIES)
+
+mark_as_advanced(CBLAS_INCLUDE_DIR CBLAS_LIBRARIES)

--- a/kernel/pl_project_oblique_stereographic.opencl
+++ b/kernel/pl_project_oblique_stereographic.opencl
@@ -17,7 +17,7 @@ float8 phi_sph2ell(float8 phi, float ecc, float k0, float c0) {
     do {
         phi = phi_ell;
         phi_ell = 2.f * atan(num * srat(ecc * sin(phi), -0.5f * ecc)) - M_PI_2F;
-    } while (any(fabs(phi_ell - phi)) > TOL7 && --i);
+    } while (any(fabs(phi_ell - phi) > TOL7) && --i);
 
     return phi_ell;
 }

--- a/src/projcl_run.c
+++ b/src/projcl_run.c
@@ -13,7 +13,14 @@
 
 #include <math.h>
 #include <stdlib.h>
+#ifdef __APPLE__
 #include <Accelerate/Accelerate.h>
+#endif
+#ifdef __linux__
+#include "cblas.h"
+typedef int __CLPK_integer;
+typedef float __CLPK_real;
+#endif
 
 #define RAD_TO_DEG	57.29577951308232
 #define DEG_TO_RAD	.0174532925199432958

--- a/test/projcl_test.c
+++ b/test/projcl_test.c
@@ -3,7 +3,13 @@
 #include <math.h>
 #include <string.h>
 
+#ifdef __APPLE__
 #include <OpenCL/opencl.h>
+#include <unistd.h>
+#else
+#include <CL/cl.h>
+#endif
+
 #include <sys/time.h>
 #include <projcl/projcl.h>
 #include <projcl/projcl_warp.h>
@@ -686,7 +692,12 @@ int compile_module(PLContext *ctx, unsigned int module, char *name) {
 int main(int argc, char **argv) {
     cl_int error = CL_SUCCESS;
     PLCode *code = NULL;
-    PLContext *ctx = pl_context_init(CL_DEVICE_TYPE_CPU, &error);
+    cl_device_type devtype = CL_DEVICE_TYPE_GPU;
+    if(argc > 1) {
+      if (!strcmp(argv[1], "-CPU"))
+	devtype = CL_DEVICE_TYPE_CPU;
+    }
+    PLContext *ctx = pl_context_init(devtype, &error);
     if (ctx == NULL) {
         printf("Failed to initialize context: %d\n", error);
         return 1;


### PR DESCRIPTION
This worked out of the box on macOS, and still does; now the test program uses your OpenCL GPU by default, and can use your OpenCL CPU with the -CPU command-line argument.

My long-range goal is to get GPU-enabled proj4 into our processing pipeline here at the [Direct Readout Lab](https://directreadout.sci.gsfc.nasa.gov/).  Our geotiff software spends about half its time inside proj4 right now, so this should be a serious improvement.

To make it work for our data, I need to:

- Make it work for double-precision floats
- Feed it data as separate lat and lon arrays instead of interspersed

As those changes will probably be pretty invasive, I figured the polite thing to do was push the platform changes separately.